### PR TITLE
Refactor tag fetching to single query

### DIFF
--- a/aldryn_newsblog/managers.py
+++ b/aldryn_newsblog/managers.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 
 import datetime
 from collections import Counter
-from operator import attrgetter
+from django.db.models import Count
 
 from django.db import models
 from django.utils.timezone import now
@@ -12,7 +12,7 @@ from django.utils.timezone import now
 from aldryn_apphooks_config.managers.base import ManagerMixin, QuerySetMixin
 from aldryn_people.models import Person
 from parler.managers import TranslatableManager, TranslatableQuerySet
-from taggit.models import Tag, TaggedItem
+from taggit.models import Tag
 
 from aldryn_newsblog.compat import toolbar_edit_mode_active
 
@@ -102,17 +102,11 @@ class RelatedManager(ManagerMixin, TranslatableManager):
         if not articles:
             # return empty iterable early not to perform useless requests
             return []
-        kwargs = TaggedItem.bulk_lookup_kwargs(articles)
 
-        # aggregate and sort
-        counted_tags = dict(TaggedItem.objects
-                            .filter(**kwargs)
-                            .values('tag')
-                            .annotate(tag_count=models.Count('tag'))
-                            .values_list('tag', 'tag_count'))
+        tags = Tag.objects.filter(
+            taggit_taggeditem__object_id__in=articles.values("pk")
+        ).annotate(
+            num_articles=Count("taggit_taggeditem")
+        ).order_by("-num_articles")
 
-        # and finally get the results
-        tags = Tag.objects.filter(pk__in=counted_tags.keys())
-        for tag in tags:
-            tag.num_articles = counted_tags[tag.pk]
-        return sorted(tags, key=attrgetter('num_articles'), reverse=True)
+        return tags

--- a/aldryn_newsblog/tests/test_managers.py
+++ b/aldryn_newsblog/tests/test_managers.py
@@ -24,3 +24,22 @@ class TestManagers(NewsBlogTestCase):
         article_url = article.get_absolute_url()
         response = self.client.get(article_url)
         self.assertEqual(response.status_code, 404)
+
+    def test_get_tags_returns_ordered_counts(self):
+        tag_names = ("tag foo", "tag bar", "tag buzz")
+
+        # create unpublished article to ensure it is ignored
+        self.create_tagged_articles(1, tags=(tag_names[0],), is_published=False)
+
+        tag_slug2 = list(
+            self.create_tagged_articles(3, tags=(tag_names[1],)).keys()
+        )[0]
+        tag_slug3 = list(
+            self.create_tagged_articles(5, tags=(tag_names[2],)).keys()
+        )[0]
+
+        tags = Article.objects.get_tags(
+            request=None, namespace=self.app_config.namespace
+        )
+        tags = [(tag.slug, tag.num_articles) for tag in tags]
+        self.assertEqual(tags, [(tag_slug3, 5), (tag_slug2, 3)])


### PR DESCRIPTION
## Summary
- simplify `get_tags` to use one ORM query with annotation for article counts
- add a test ensuring tags are returned ordered by usage and exclude unpublished articles

## Testing
- ⚠️ `pytest aldryn_newsblog/tests/test_managers.py::TestManagers::test_get_tags_returns_ordered_counts -q` *(failed: RuntimeError: Model class django.contrib.contenttypes.models.ContentType doesn't declare an explicit app_label and isn't in INSTALLED_APPS)*

------
https://chatgpt.com/codex/tasks/task_e_68a35cc382dc832e896cbc6c70a5db25