### PR TITLE
Add composite index for Article listing

### DIFF
--- a/aldryn_newsblog/migrations/0017_article_listing_index.py
+++ b/aldryn_newsblog/migrations/0017_article_listing_index.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('aldryn_newsblog', '0016_auto_20180329_1417'),
+    ]
+
+    operations = [
+        migrations.AddIndex(
+            model_name='article',
+            index=models.Index(fields=['is_published', '-publishing_date', 'app_config'], name='newsblog_article_listing_idx'),
+        ),
+    ]

--- a/aldryn_newsblog/models.py
+++ b/aldryn_newsblog/models.py
@@ -165,6 +165,11 @@ class Article(TranslatedAutoSlugifyMixin,
 
     class Meta:
         ordering = ['-publishing_date']
+        indexes = [
+            models.Index(
+                fields=['is_published', '-publishing_date', 'app_config'],
+            ),
+        ]
 
     @property
     def published(self):


### PR DESCRIPTION
## Summary
- add composite index on Article for published status, publishing date, and app config
- include migration to create the new index

## Testing
- `DJANGO_SETTINGS_MODULE=migrate_settings python -m django migrate --noinput`
- `DJANGO_SETTINGS_MODULE=migrate_settings python - <<'PY'
from django.db import connection
cursor = connection.cursor()
cursor.execute("EXPLAIN QUERY PLAN SELECT * FROM aldryn_newsblog_article WHERE is_published=1 AND app_config_id=1 ORDER BY publishing_date DESC")
print(cursor.fetchall())
PY`
- `DJANGO_SETTINGS_MODULE=migrate_settings python -m django test aldryn_newsblog --verbosity 2` *(fails: TemplateDoesNotExist: INHERIT)*

------
https://chatgpt.com/codex/tasks/task_e_68a37ee02648832e8b52e682660a0f79