### PR TITLE
Use Subquery for tag lookup in get_tags

### DIFF
--- a/aldryn_newsblog/managers.py
+++ b/aldryn_newsblog/managers.py
@@ -98,9 +98,11 @@ class RelatedManager(ManagerMixin, TranslatableManager):
             # return empty iterable early not to perform useless requests
             return []
 
+        from django.db.models import Subquery
+
         tags = Tag.objects.filter(
-            taggit_taggeditem__object_id__in=articles.values("pk")
-        ).annotate(
+            taggit_taggeditem__object_id__in=Subquery(articles.only("pk"))
+        ).prefetch_related('taggit_taggeditem__tag').annotate(
             num_articles=Count("taggit_taggeditem")
         ).order_by("-num_articles")
 


### PR DESCRIPTION
## Summary
- use `Subquery` for tag-object filtering in `get_tags`
- prefetch tag names for efficiency

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68a37ebed59c832e917ce6ecb9314083