### PR TITLE
Fix translation field defer in ArticleList queryset

### DIFF
--- a/aldryn_newsblog/views.py
+++ b/aldryn_newsblog/views.py
@@ -270,7 +270,7 @@ class ArticleList(ArticleListBase):
                 "translations",
                 "tagged_items__tag",
             )
-            .defer("content", "lead_in")
+            .defer("content", "translations__lead_in")
         )
         # exclude featured articles from queryset, to allow featured article
         # plugin on the list view page without duplicate entries in page qs.


### PR DESCRIPTION
## Summary
- adjust ArticleList queryset to defer translated `lead_in` correctly

## Testing
- `python test_settings.py` (fails: djangocms_helper and legacy deps incompatible with Python 3.13)


------
https://chatgpt.com/codex/tasks/task_e_68a4a9a63fe4832e8244465355452567